### PR TITLE
Version Update and Comparison Fix (#287)

### DIFF
--- a/src/InstagramApiSharp/API/Builder/InstaApiBuilder.cs
+++ b/src/InstagramApiSharp/API/Builder/InstaApiBuilder.cs
@@ -71,7 +71,7 @@ namespace InstagramApiSharp.API.Builder
                     new HttpRequestProcessor(_delay, _httpClient, _httpHandler, _requestMessage, _logger);
 
             if (_apiVersionType == null)
-                _apiVersionType = InstaApiVersionType.Version86;
+                _apiVersionType = InstaApiVersionType.Version107;
 
             var instaApi = new InstaApi(_user, _logger, _device, _httpRequestProcessor, _apiVersionType.Value);
             if (_sessionHandler != null)

--- a/src/InstagramApiSharp/API/InstaApi.cs
+++ b/src/InstagramApiSharp/API/InstaApi.cs
@@ -2606,7 +2606,7 @@ namespace InstagramApiSharp.API
             }
 
             if (data.InstaApiVersion == null)
-                data.InstaApiVersion = InstaApiVersionType.Version86;
+                data.InstaApiVersion = InstaApiVersionType.Version107;
             _apiVersionType = data.InstaApiVersion.Value;
             _apiVersion = InstaApiVersionList.GetApiVersionList().GetApiVersion(_apiVersionType);
             _httpHelper = new HttpHelper(_apiVersion);
@@ -2639,7 +2639,7 @@ namespace InstagramApiSharp.API
             }
 
             if (data.InstaApiVersion == null)
-                data.InstaApiVersion = InstaApiVersionType.Version86;
+                data.InstaApiVersion = InstaApiVersionType.Version107;
             _apiVersionType = data.InstaApiVersion.Value;
             _apiVersion = InstaApiVersionList.GetApiVersionList().GetApiVersion(_apiVersionType);
             _httpHelper = new HttpHelper(_apiVersion);
@@ -2674,7 +2674,7 @@ namespace InstagramApiSharp.API
             }
 
             if (stateData.InstaApiVersion == null)
-                stateData.InstaApiVersion = InstaApiVersionType.Version86;
+                stateData.InstaApiVersion = InstaApiVersionType.Version107;
             _apiVersionType = stateData.InstaApiVersion.Value;
             _apiVersion = InstaApiVersionList.GetApiVersionList().GetApiVersion(_apiVersionType);
             _httpHelper = new HttpHelper(_apiVersion);

--- a/src/InstagramApiSharp/API/Versions/InstaApiVersionList.cs
+++ b/src/InstagramApiSharp/API/Versions/InstaApiVersionList.cs
@@ -90,6 +90,16 @@ namespace InstagramApiSharp.API.Versions
                          Capabilities = "3brTvw==",
                          SignatureKey = "19ce5f445dbfd9d29c59dc2a78c616a7fc090a8e018b9267bc4240a30244c53b"
                     }
+                },
+                {
+                    InstaApiVersionType.Version107,
+                    new InstaApiVersion
+                    {
+                         AppApiVersionCode = "168361634",
+                         AppVersion = "107.0.0.27.121",
+                         Capabilities = "3brTvw==",
+                         SignatureKey = "c36436a942ea1dbb40d7f2d7d45280a620d991ce8c62fb4ce600f0a048c32c11"
+                    }
                 }
             };
         }

--- a/src/InstagramApiSharp/Enums/InstaApiVersionType.cs
+++ b/src/InstagramApiSharp/Enums/InstaApiVersionType.cs
@@ -38,6 +38,10 @@ namespace InstagramApiSharp.Enums
         /// <summary>
         ///     Api version 86.0.0.24.87
         /// </summary>
-        Version86 = 6
+        Version86 = 6,
+        /// <summary>
+        ///     Api version 107.0.0.27.121
+        /// </summary>
+        Version107 = 7
     }
 }

--- a/src/InstagramApiSharp/Helpers/ErrorHandlingHelper.cs
+++ b/src/InstagramApiSharp/Helpers/ErrorHandlingHelper.cs
@@ -11,7 +11,7 @@ namespace InstagramApiSharp.Helpers
             var badStatus = new BadStatusResponse();
             try
             {
-                if (json == "Oops, an error occurred\n")
+                if (json.Contains("Oops, an error occurred"))
                     badStatus.Message = json;
                 else badStatus = JsonConvert.DeserializeObject<BadStatusResponse>(json);
             }


### PR DESCRIPTION
* Update ErrorHandlingHelper.cs

Comparison fix to validate Instagram unavailability

* Update api version to 107.0.0.27.121 (it's default now).

* Set default version to highest